### PR TITLE
relax base upper bound

### DIFF
--- a/horizon.cabal
+++ b/horizon.cabal
@@ -14,13 +14,13 @@ stability:           provisional
 homepage:            https://github.com/intractable/horizon
 bug-reports:         https://github.com/intractable/horizon/issues
 Package-url:         http://hackage.haskell.org/package/horizon
-tested-with:         GHC == 7.8.3                        
+tested-with:         GHC == 7.8.3, GHC == 8.2.2
 
 library
   exposed-modules:     Data.Time.Horizon
   -- other-modules:
   -- other-extensions:
-  build-depends:       base >=4.7      && < 4.8,
+  build-depends:       base >=4.7      && < 5.0,
                        time,
                        AC-Angle >= 1.0 && < 2.0
   hs-source-dirs:      src


### PR DESCRIPTION
Tested working up to base-4.10 (ghc 8.2.2).

I've chosen to relax the bound to allow any base until the next major
version. Minor versions of base seem very unlikely to break this
library, since the only parts of base it depends on are the Prelude and
Data.Fixed. This is quite a common choice throughout hackage;
see https://packdeps.haskellers.com/reverse/base

closes https://github.com/intractable/horizon/issues/2